### PR TITLE
[feat] 버튼 컴포넌트 생성

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@vitejs/plugin-react": "^4.4.1",
     "@vitest/browser": "^3.1.4",
     "@vitest/coverage-v8": "^3.1.4",
+    "clsx": "^2.1.1",
     "eslint": "^9.25.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^3.1.4
         version: 3.1.4(@vitest/browser@3.1.4)(vitest@3.1.4)
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       eslint:
         specifier: ^9.25.0
         version: 9.27.0(jiti@2.4.2)
@@ -1171,6 +1174,10 @@ packages:
         optional: true
       '@chromatic-com/playwright':
         optional: true
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -3406,6 +3413,8 @@ snapshots:
   chownr@3.0.0: {}
 
   chromatic@11.28.2: {}
+
+  clsx@2.1.1: {}
 
   color-convert@2.0.1:
     dependencies:

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -1,7 +1,8 @@
+import ExhibitionButton from './button/ExhibitionButton';
 import Layout from './common/Layout';
 
 export default function Home() {
-  const components = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+  const components = [<ExhibitionButton />, 2, 3, 4, 5, 6, 7, 8, 9];
   return (
     <main className="grid w-full h-full grid-cols-3 grid-rows-3 ">
       {components.map((el) => (

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -1,0 +1,12 @@
+import { useButton } from '../../hooks/useButton';
+import type { ButtonProps } from '@/types/button';
+
+export default function Button({ data }: { data: ButtonProps }) {
+  const { text, buttonStyle, disabled, onClick } = useButton(data);
+
+  return (
+    <button className={` ${buttonStyle}`} disabled={disabled} onClick={onClick}>
+      {text}
+    </button>
+  );
+}

--- a/src/components/button/ExhibitionButton.tsx
+++ b/src/components/button/ExhibitionButton.tsx
@@ -1,0 +1,26 @@
+import type { ButtonProps } from '../../types/button';
+import Button from './Button';
+
+export default function ExhibitionButton() {
+  const data: ButtonProps = {
+    type: 'plain',
+    size: 'md',
+    text: 'button',
+  };
+
+  return (
+    <div className="grid grid-rows-3 grid-cols-3 gap-2 place-items-center">
+      <Button data={{ ...data, size: 'sm' }} />
+      <Button data={{ ...data, type: 'text', size: 'sm' }} />
+      <Button data={{ ...data, size: 'sm', disabled: true }} />
+
+      <Button data={data} />
+      <Button data={{ ...data, type: 'text' }} />
+      <Button data={{ ...data, disabled: true }} />
+
+      <Button data={{ ...data, size: 'lg' }} />
+      <Button data={{ ...data, type: 'text', size: 'lg' }} />
+      <Button data={{ ...data, size: 'lg', disabled: true }} />
+    </div>
+  );
+}

--- a/src/hooks/useButton.ts
+++ b/src/hooks/useButton.ts
@@ -1,0 +1,24 @@
+import type { ButtonProps } from '../types/button';
+import clsx from 'clsx';
+
+const ButtonSize = {
+  sm: 'w-11 h-5 text-xs p-1',
+  md: 'w-22 h-9 px-4 py-2',
+  lg: 'w-30 h-10 text-lg px-6 py-2',
+  xl: 'w-40 h-15 px-6 py-4',
+};
+
+export const useButton = ({ size, text, type, disabled, onClick }: ButtonProps) => {
+  const buttonStyle = clsx(
+    'border flex justify-center items-center rounded-md transition box-border outline-none',
+    {
+      'cursor-pointer': !disabled,
+      'hover:bg-gray-300': !disabled && type !== 'text',
+      'bg-gray-200 hover:bg-gray-200 text-gray-600 cursor-not-allowed': disabled,
+      'border-none hover:bg-transparent hover:font-semibold': type === 'text',
+    },
+    ButtonSize[size]
+  );
+
+  return { text, type, buttonStyle, disabled, onClick };
+};

--- a/src/types/button.ts
+++ b/src/types/button.ts
@@ -1,0 +1,10 @@
+type ButtonType = 'plain' | 'text';
+type ButtonSize = 'sm' | 'md' | 'lg' | 'xl';
+
+export type ButtonProps = {
+  type: ButtonType;
+  text: string;
+  onClick?: () => void;
+  disabled?: boolean;
+  size: ButtonSize;
+};

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,5 +1,18 @@
 {
   "compilerOptions": {
+    /* Absolute Path */
+    "baseUrl": "./src",
+    "paths": {
+      "@/*": ["/*"],
+      "@/components/*": ["components/*"],
+      "@/hooks/*": ["hooks/*"],
+      "@/mocks/*": ["mocks/*"],
+      "@/routes/*": ["routes/*"],
+      "@/stories/*": ["stories/*"],
+      "@/tests/*": ["tests/*"],
+      "@/types/*": ["types/*"],
+      "@/utils/*": ["utils/*"]
+    },
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "ES2020",
     "useDefineForClassFields": true,


### PR DESCRIPTION
## 연관된 이슈

> #2 

## 작업 내용
1. 버튼 컴포넌트 생성 
2. props(사이즈, 종류)에 따른 스타일 지정
3. 컴포넌트 import 경로 절대 경로 설정

## 스크린샷
