### PR TITLE
[refactor] carousel 라이브러리 사용 없이 직접 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - [ ] 버튼
 - [ ] 인풋
 - [ ] 모달
-- [ ] carousel(Netflix)
+- [ ] carousel(Netflix) - 라이브러리 사용 없이 직접 구현
 - [ ] search bar(AirBnB)
 - [ ] select box(AirBnB, 여행지 선택)
 - [ ] calendar(AirBnB)

--- a/src/assets/close.svg
+++ b/src/assets/close.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" fill="none" role="img" viewBox="0 0 24 24" width="24" height="24" data-icon="XStandard" aria-hidden="true">
-<path fill="currentColor" d="M10.5858 12L2.29291 3.70706L3.70712 2.29285L12 10.5857L20.2929 2.29285L21.7071 3.70706L13.4142 12L21.7071 20.2928L20.2929 21.7071L12 13.4142L3.70712 21.7071L2.29291 20.2928L10.5858 12Z" clip-rule="evenodd" fill-rule="evenodd"></path>
+<svg xmlns="http://www.w3.org/2000/svg" fill="white" role="img" viewBox="0 0 24 24" width="24" height="24" data-icon="XStandard" aria-hidden="true">
+<path fill="white" d="M10.5858 12L2.29291 3.70706L3.70712 2.29285L12 10.5857L20.2929 2.29285L21.7071 3.70706L13.4142 12L21.7071 20.2928L20.2929 21.7071L12 13.4142L3.70712 21.7071L2.29291 20.2928L10.5858 12Z" clip-rule="evenodd" fill-rule="evenodd"></path>
 
 </svg>

--- a/src/components/button/CarouselArrow.tsx
+++ b/src/components/button/CarouselArrow.tsx
@@ -5,7 +5,6 @@ type ArrowProps = {
 };
 
 export default function CarouselArrow({ className, style, onClick }: ArrowProps) {
-  console.log('ss: ', style);
   return (
     <div
       className={className}

--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -6,13 +6,19 @@ type ModalProps = {
   onClose: Dispatch<SetStateAction<boolean>>;
   children: React.ReactNode;
   domNode?: Element;
+  isCloseOnClickOutside?: boolean;
 };
 
-export default function Modal({ children, onClose, domNode }: ModalProps) {
+export default function Modal({
+  children,
+  onClose,
+  domNode,
+  isCloseOnClickOutside = true,
+}: ModalProps) {
   const [isActive, setIsActive] = useState(false);
 
   const handleClickOutSide = (e: React.MouseEvent) => {
-    if (e.target === e.currentTarget) {
+    if (e.target === e.currentTarget && isCloseOnClickOutside) {
       onClose((prev) => !prev);
     }
   };
@@ -34,10 +40,10 @@ export default function Modal({ children, onClose, domNode }: ModalProps) {
       }`}
       onClick={handleClickOutSide}
     >
-      <div className="flex justify-center items-center w-[40%] h-[40%] p-4 bg-white relative rounded-md">
+      <div className="flex justify-center items-center w-[40%] h-[40%] bg-white relative rounded-md">
         <div
           className={`absolute right-3 top-3 border border-transparent rounded-full p-2 cursor-pointer transition ${
-            isActive ? 'bg-gray-200' : ''
+            isActive ? 'bg-gray-500' : ''
           }`}
           onMouseEnter={handleEnter}
           onMouseLeave={handleLeave}

--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -1,4 +1,4 @@
-import { useState, type Dispatch, type SetStateAction } from 'react';
+import { useCallback, useEffect, useState, type Dispatch, type SetStateAction } from 'react';
 import { createPortal } from 'react-dom';
 import CloseIcon from '@/assets/close.svg';
 
@@ -7,6 +7,7 @@ type ModalProps = {
   children: React.ReactNode;
   domNode?: Element;
   isCloseOnClickOutside?: boolean;
+  isCloseOnEsc?: boolean;
 };
 
 export default function Modal({
@@ -14,6 +15,7 @@ export default function Modal({
   onClose,
   domNode,
   isCloseOnClickOutside = true,
+  isCloseOnEsc = true,
 }: ModalProps) {
   const [isActive, setIsActive] = useState(false);
 
@@ -32,6 +34,23 @@ export default function Modal({
       setIsActive(false);
     }, 300);
   };
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.code === 'Escape' && isCloseOnEsc) {
+        onClose((prev) => !prev);
+      }
+    },
+    [onClose, isCloseOnEsc]
+  );
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [onClose, handleKeyDown]);
 
   return createPortal(
     <section

--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -21,7 +21,7 @@ export default function Modal({
 
   const handleClickOutSide = (e: React.MouseEvent) => {
     if (e.target === e.currentTarget && isCloseOnClickOutside) {
-      onClose((prev) => !prev);
+      onClose(false);
     }
   };
 
@@ -38,7 +38,7 @@ export default function Modal({
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
       if (e.code === 'Escape' && isCloseOnEsc) {
-        onClose((prev) => !prev);
+        onClose(false);
       }
     },
     [onClose, isCloseOnEsc]
@@ -66,7 +66,7 @@ export default function Modal({
           }`}
           onMouseEnter={handleEnter}
           onMouseLeave={handleLeave}
-          onClick={() => onClose((prev) => !prev)}
+          onClick={() => onClose(false)}
         >
           <img src={CloseIcon} alt="close icon" />
         </div>

--- a/src/components/modal/RankingMovieDetailModal.tsx
+++ b/src/components/modal/RankingMovieDetailModal.tsx
@@ -1,0 +1,52 @@
+import Modal from '@/components/modal/Modal';
+import type { RankingMovieProps } from '@/types/movie';
+import { useEffect, useState, type SetStateAction } from 'react';
+
+type RankingMovieDetailModalProps = Pick<RankingMovieProps, 'categories' | 'description'> & {
+  isModalOpen: boolean;
+  closeModal: React.Dispatch<SetStateAction<boolean>>;
+};
+
+export default function RankingMovieDetailModal({
+  categories,
+  description,
+  isModalOpen,
+  closeModal,
+}: RankingMovieDetailModalProps) {
+  const [blur, setBlur] = useState(true);
+
+  const handleLoad = () => {
+    setTimeout(() => {
+      setBlur(false);
+    }, 500);
+  };
+
+  useEffect(() => {
+    setBlur(true);
+  }, [isModalOpen]);
+
+  return (
+    <Modal onClose={closeModal}>
+      <div className="flex flex-col items-center w-full h-full overflow-hidden">
+        <div className="w-full flex justify-center">
+          <img
+            src={
+              'https://occ-0-1360-2218.1.nflxso.net/dnm/api/v6/Z-WHgqd_TeJxSuha8aZ5WpyLcX8/AAAABRv_Xv-t534pVH-OoHaS5k9MrfulGcsIwdHjJsT9UiNmsR8q_RPPJvYQUPAwVD9qpEj6ug5TnxbCONYrKJt88FpPSjfpxT_7Cdmc.webp?r=41e'
+            }
+            alt="movie detail image"
+            className={`max-w-full h-auto object-cover transition ${blur ? 'blur-lg' : ''}`}
+            onLoad={handleLoad}
+          />
+        </div>
+        <ul className="flex space-x-2 mb-4">
+          {categories?.map((c) => (
+            <li key={c} className="bg-slate-300 p-1 rounded-md text-gray-500 font-semibold text-sm">
+              {c}
+            </li>
+          ))}
+        </ul>
+        <p>{description}</p>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/movie/RankingMovie.tsx
+++ b/src/components/movie/RankingMovie.tsx
@@ -1,6 +1,6 @@
-import Modal from '@/components/modal/Modal';
+import RankingMovieDetailModal from '@/components/modal/RankingMovieDetailModal';
+import { useModal } from '@/hooks/useModal';
 import type { RankingMovieProps } from '@/types/movie';
-import { useState } from 'react';
 
 export default function RankingMovie({
   ranking,
@@ -8,17 +8,13 @@ export default function RankingMovie({
   categories,
   description,
 }: RankingMovieProps) {
-  const [modalOpen, setModalOpen] = useState(false);
-
-  const handleClickMovie = () => {
-    setModalOpen(true);
-  };
+  const { isModalOpen, openModal, closeModal } = useModal();
 
   return (
     <>
       <section
         className="w-56 h-64 relative p-5 transition cursor-pointer hover:scale-105 overflow-hidden rounded-md"
-        onClick={handleClickMovie}
+        onClick={openModal}
       >
         <img src={thumbnail} className="rounded-md" alt="movie thumbnail image" />
         <span className="absolute bottom-3 -left-0.5 text-6xl font-bold text-stroke-white">
@@ -26,22 +22,13 @@ export default function RankingMovie({
         </span>
       </section>
 
-      {modalOpen && (
-        <Modal onClose={setModalOpen}>
-          <div className="flex flex-col w-full h-full">
-            <ul className="flex space-x-2 mb-4">
-              {categories?.map((c) => (
-                <li
-                  key={c}
-                  className="bg-slate-300 p-1 rounded-md text-gray-500 font-semibold text-sm"
-                >
-                  {c}
-                </li>
-              ))}
-            </ul>
-            <p>{description}</p>
-          </div>
-        </Modal>
+      {isModalOpen && (
+        <RankingMovieDetailModal
+          categories={categories}
+          description={description}
+          isModalOpen={isModalOpen}
+          closeModal={closeModal}
+        />
       )}
     </>
   );

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -1,0 +1,9 @@
+import { useState } from 'react';
+
+export function useModal() {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const openModal = () => setIsModalOpen(true);
+  const closeModal = () => setIsModalOpen(false);
+
+  return { isModalOpen, openModal, closeModal };
+}


### PR DESCRIPTION
## 연관된 이슈

> #8 

## 작업 내용

- carousel 직접 구현(작업 중): slidesToShow, slidesToScroll 기능, 좌우 슬라이드 버튼
- carousel 직접 구현(미진행): infinite scroll, auto play(& speed), draggable, 터치 패드 스와이프 기능

## 스크린샷
