### PR TITLE
[refactor] carousel 라이브러리 사용 없이 직접 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@chromatic-com/storybook": "^3.2.6",
     "@eslint/js": "^9.25.0",
     "@tailwindcss/vite": "^4.1.7",
+    "@types/node": "^24.0.1",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react": "^4.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,7 +41,10 @@ importers:
         version: 9.27.0
       '@tailwindcss/vite':
         specifier: ^4.1.7
-        version: 4.1.7(vite@6.3.5(jiti@2.4.2)(lightningcss@1.30.1))
+        version: 4.1.7(vite@6.3.5(@types/node@24.0.1)(jiti@2.4.2)(lightningcss@1.30.1))
+      '@types/node':
+        specifier: ^24.0.1
+        version: 24.0.1
       '@types/react':
         specifier: ^19.1.2
         version: 19.1.5
@@ -50,10 +53,10 @@ importers:
         version: 19.1.5(@types/react@19.1.5)
       '@vitejs/plugin-react':
         specifier: ^4.4.1
-        version: 4.4.1(vite@6.3.5(jiti@2.4.2)(lightningcss@1.30.1))
+        version: 4.4.1(vite@6.3.5(@types/node@24.0.1)(jiti@2.4.2)(lightningcss@1.30.1))
       '@vitest/browser':
         specifier: ^3.1.4
-        version: 3.1.4(playwright@1.52.0)(vite@6.3.5(jiti@2.4.2)(lightningcss@1.30.1))(vitest@3.1.4)
+        version: 3.1.4(playwright@1.52.0)(vite@6.3.5(@types/node@24.0.1)(jiti@2.4.2)(lightningcss@1.30.1))(vitest@3.1.4)
       '@vitest/coverage-v8':
         specifier: ^3.1.4
         version: 3.1.4(@vitest/browser@3.1.4)(vitest@3.1.4)
@@ -89,13 +92,13 @@ importers:
         version: 8.32.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.3)
       vite:
         specifier: ^6.3.5
-        version: 6.3.5(jiti@2.4.2)(lightningcss@1.30.1)
+        version: 6.3.5(@types/node@24.0.1)(jiti@2.4.2)(lightningcss@1.30.1)
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@5.8.3)(vite@6.3.5(jiti@2.4.2)(lightningcss@1.30.1))
+        version: 5.1.4(typescript@5.8.3)(vite@6.3.5(@types/node@24.0.1)(jiti@2.4.2)(lightningcss@1.30.1))
       vitest:
         specifier: ^3.1.4
-        version: 3.1.4(@vitest/browser@3.1.4)(jiti@2.4.2)(lightningcss@1.30.1)
+        version: 3.1.4(@types/node@24.0.1)(@vitest/browser@3.1.4)(jiti@2.4.2)(lightningcss@1.30.1)
 
 packages:
 
@@ -697,6 +700,9 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/node@24.0.1':
+    resolution: {integrity: sha512-MX4Zioh39chHlDJbKmEgydJDS3tspMP/lnQC67G3SWsTnb9NeYVWOjkxpOSy4oMfPs4StcWHwBrvUb4ybfnuaw==}
 
   '@types/react-dom@19.1.5':
     resolution: {integrity: sha512-CMCjrWucUBZvohgZxkjd6S9h0nZxXjzus6yDfUb+xLxYM7VvjKNH1tQrE9GWLql1XoOP4/Ds3bwFqShHUYraGg==}
@@ -1888,6 +1894,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  undici-types@7.8.0:
+    resolution: {integrity: sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==}
+
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
@@ -2510,12 +2519,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.1.7
       '@tailwindcss/oxide-win32-x64-msvc': 4.1.7
 
-  '@tailwindcss/vite@4.1.7(vite@6.3.5(jiti@2.4.2)(lightningcss@1.30.1))':
+  '@tailwindcss/vite@4.1.7(vite@6.3.5(@types/node@24.0.1)(jiti@2.4.2)(lightningcss@1.30.1))':
     dependencies:
       '@tailwindcss/node': 4.1.7
       '@tailwindcss/oxide': 4.1.7
       tailwindcss: 4.1.7
-      vite: 6.3.5(jiti@2.4.2)(lightningcss@1.30.1)
+      vite: 6.3.5(@types/node@24.0.1)(jiti@2.4.2)(lightningcss@1.30.1)
 
   '@testing-library/dom@10.4.0':
     dependencies:
@@ -2558,6 +2567,10 @@ snapshots:
   '@types/estree@1.0.7': {}
 
   '@types/json-schema@7.0.15': {}
+
+  '@types/node@24.0.1':
+    dependencies:
+      undici-types: 7.8.0
 
   '@types/react-dom@19.1.5(@types/react@19.1.5)':
     dependencies:
@@ -2648,27 +2661,27 @@ snapshots:
       '@typescript-eslint/types': 8.32.1
       eslint-visitor-keys: 4.2.0
 
-  '@vitejs/plugin-react@4.4.1(vite@6.3.5(jiti@2.4.2)(lightningcss@1.30.1))':
+  '@vitejs/plugin-react@4.4.1(vite@6.3.5(@types/node@24.0.1)(jiti@2.4.2)(lightningcss@1.30.1))':
     dependencies:
       '@babel/core': 7.27.1
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.27.1)
       '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.27.1)
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.3.5(jiti@2.4.2)(lightningcss@1.30.1)
+      vite: 6.3.5(@types/node@24.0.1)(jiti@2.4.2)(lightningcss@1.30.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/browser@3.1.4(playwright@1.52.0)(vite@6.3.5(jiti@2.4.2)(lightningcss@1.30.1))(vitest@3.1.4)':
+  '@vitest/browser@3.1.4(playwright@1.52.0)(vite@6.3.5(@types/node@24.0.1)(jiti@2.4.2)(lightningcss@1.30.1))(vitest@3.1.4)':
     dependencies:
       '@testing-library/dom': 10.4.0
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
-      '@vitest/mocker': 3.1.4(vite@6.3.5(jiti@2.4.2)(lightningcss@1.30.1))
+      '@vitest/mocker': 3.1.4(vite@6.3.5(@types/node@24.0.1)(jiti@2.4.2)(lightningcss@1.30.1))
       '@vitest/utils': 3.1.4
       magic-string: 0.30.17
       sirv: 3.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.1.4(@vitest/browser@3.1.4)(jiti@2.4.2)(lightningcss@1.30.1)
+      vitest: 3.1.4(@types/node@24.0.1)(@vitest/browser@3.1.4)(jiti@2.4.2)(lightningcss@1.30.1)
       ws: 8.18.2
     optionalDependencies:
       playwright: 1.52.0
@@ -2692,9 +2705,9 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.1.4(@vitest/browser@3.1.4)(jiti@2.4.2)(lightningcss@1.30.1)
+      vitest: 3.1.4(@types/node@24.0.1)(@vitest/browser@3.1.4)(jiti@2.4.2)(lightningcss@1.30.1)
     optionalDependencies:
-      '@vitest/browser': 3.1.4(playwright@1.52.0)(vite@6.3.5(jiti@2.4.2)(lightningcss@1.30.1))(vitest@3.1.4)
+      '@vitest/browser': 3.1.4(playwright@1.52.0)(vite@6.3.5(@types/node@24.0.1)(jiti@2.4.2)(lightningcss@1.30.1))(vitest@3.1.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -2705,13 +2718,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.1.4(vite@6.3.5(jiti@2.4.2)(lightningcss@1.30.1))':
+  '@vitest/mocker@3.1.4(vite@6.3.5(@types/node@24.0.1)(jiti@2.4.2)(lightningcss@1.30.1))':
     dependencies:
       '@vitest/spy': 3.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.3.5(jiti@2.4.2)(lightningcss@1.30.1)
+      vite: 6.3.5(@types/node@24.0.1)(jiti@2.4.2)(lightningcss@1.30.1)
 
   '@vitest/pretty-format@3.1.4':
     dependencies:
@@ -3735,6 +3748,8 @@ snapshots:
 
   typescript@5.8.3: {}
 
+  undici-types@7.8.0: {}
+
   universalify@2.0.1: {}
 
   update-browserslist-db@1.1.3(browserslist@4.24.5):
@@ -3755,13 +3770,13 @@ snapshots:
       is-typed-array: 1.1.15
       which-typed-array: 1.1.19
 
-  vite-node@3.1.4(jiti@2.4.2)(lightningcss@1.30.1):
+  vite-node@3.1.4(@types/node@24.0.1)(jiti@2.4.2)(lightningcss@1.30.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.3.5(jiti@2.4.2)(lightningcss@1.30.1)
+      vite: 6.3.5(@types/node@24.0.1)(jiti@2.4.2)(lightningcss@1.30.1)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -3776,18 +3791,18 @@ snapshots:
       - tsx
       - yaml
 
-  vite-tsconfig-paths@5.1.4(typescript@5.8.3)(vite@6.3.5(jiti@2.4.2)(lightningcss@1.30.1)):
+  vite-tsconfig-paths@5.1.4(typescript@5.8.3)(vite@6.3.5(@types/node@24.0.1)(jiti@2.4.2)(lightningcss@1.30.1)):
     dependencies:
       debug: 4.4.1
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.8.3)
     optionalDependencies:
-      vite: 6.3.5(jiti@2.4.2)(lightningcss@1.30.1)
+      vite: 6.3.5(@types/node@24.0.1)(jiti@2.4.2)(lightningcss@1.30.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@6.3.5(jiti@2.4.2)(lightningcss@1.30.1):
+  vite@6.3.5(@types/node@24.0.1)(jiti@2.4.2)(lightningcss@1.30.1):
     dependencies:
       esbuild: 0.25.4
       fdir: 6.4.4(picomatch@4.0.2)
@@ -3796,14 +3811,15 @@ snapshots:
       rollup: 4.41.0
       tinyglobby: 0.2.13
     optionalDependencies:
+      '@types/node': 24.0.1
       fsevents: 2.3.3
       jiti: 2.4.2
       lightningcss: 1.30.1
 
-  vitest@3.1.4(@vitest/browser@3.1.4)(jiti@2.4.2)(lightningcss@1.30.1):
+  vitest@3.1.4(@types/node@24.0.1)(@vitest/browser@3.1.4)(jiti@2.4.2)(lightningcss@1.30.1):
     dependencies:
       '@vitest/expect': 3.1.4
-      '@vitest/mocker': 3.1.4(vite@6.3.5(jiti@2.4.2)(lightningcss@1.30.1))
+      '@vitest/mocker': 3.1.4(vite@6.3.5(@types/node@24.0.1)(jiti@2.4.2)(lightningcss@1.30.1))
       '@vitest/pretty-format': 3.1.4
       '@vitest/runner': 3.1.4
       '@vitest/snapshot': 3.1.4
@@ -3820,11 +3836,12 @@ snapshots:
       tinyglobby: 0.2.13
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.3.5(jiti@2.4.2)(lightningcss@1.30.1)
-      vite-node: 3.1.4(jiti@2.4.2)(lightningcss@1.30.1)
+      vite: 6.3.5(@types/node@24.0.1)(jiti@2.4.2)(lightningcss@1.30.1)
+      vite-node: 3.1.4(@types/node@24.0.1)(jiti@2.4.2)(lightningcss@1.30.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@vitest/browser': 3.1.4(playwright@1.52.0)(vite@6.3.5(jiti@2.4.2)(lightningcss@1.30.1))(vitest@3.1.4)
+      '@types/node': 24.0.1
+      '@vitest/browser': 3.1.4(playwright@1.52.0)(vite@6.3.5(@types/node@24.0.1)(jiti@2.4.2)(lightningcss@1.30.1))(vitest@3.1.4)
     transitivePeerDependencies:
       - jiti
       - less

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -1,11 +1,12 @@
 import Carousel from '@/components/carousel/Carousel';
+import MyCarousel from '@/components/carousel/MyCarousel';
 import RankingMovie from '@/components/movie/RankingMovie';
 import { movies } from '@/mock/data';
 
 export default function Home() {
   return (
-    <main className="w-full h-full flex items-center justify-center">
-      <div className="w-[1400px]">
+    <main className="w-full h-full flex flex-col items-center justify-center">
+      <div className="w-[1400px] mb-5">
         <Carousel>
           {movies.map(({ thumbnail, ranking, description, categories }) => (
             <li key={ranking}>
@@ -20,6 +21,22 @@ export default function Home() {
             </li>
           ))}
         </Carousel>
+      </div>
+      <div className="w-[1400px]">
+        <MyCarousel>
+          {movies.map(({ thumbnail, ranking, description, categories }) => (
+            <li key={ranking}>
+              {
+                <RankingMovie
+                  thumbnail={thumbnail}
+                  ranking={ranking}
+                  description={description}
+                  categories={categories}
+                />
+              }
+            </li>
+          ))}
+        </MyCarousel>
       </div>
     </main>
   );

--- a/src/components/button/ArrowButton.tsx
+++ b/src/components/button/ArrowButton.tsx
@@ -1,0 +1,3 @@
+export default function ArrowButton() {
+  return <div className="font-bold">&lt;</div>;
+}

--- a/src/components/button/CarouselArrow.tsx
+++ b/src/components/button/CarouselArrow.tsx
@@ -5,7 +5,6 @@ type ArrowProps = {
 };
 
 export default function CarouselArrow({ className, style, onClick }: ArrowProps) {
-  console.log('ss: ', style);
   return (
     <div
       className={className}

--- a/src/components/carousel/Carousel.tsx
+++ b/src/components/carousel/Carousel.tsx
@@ -12,7 +12,7 @@ export default function Carousel({ children }: CarouselProps) {
     slidesToShow: 6,
     slidesToScroll: 5,
     draggable: true,
-    infinite: false,
+    infinite: true,
     prevArrow: <CarouselArrow />,
     nextArrow: <CarouselArrow />,
   };

--- a/src/components/carousel/MyCarousel.tsx
+++ b/src/components/carousel/MyCarousel.tsx
@@ -1,0 +1,24 @@
+import CarouselContainer, {
+  type CarouselOptions,
+} from '@/components/carousel/custom-carousel/CarouselContainer';
+
+type MyCarouselProps = {
+  children: React.ReactNode;
+};
+
+export default function MyCarousel({ children }: MyCarouselProps) {
+  const settings: CarouselOptions = {
+    slidesToShow: 6,
+    slidesToScroll: 5,
+    draggable: true,
+    infinite: false,
+    prevArrow: (
+      <div className="flex justify-center items-center bg-gray-400 px-2 py-4 rounded-md" />
+    ),
+    nextArrow: (
+      <div className="flex justify-center items-center bg-gray-400 px-2 py-4 rounded-md" />
+    ),
+  };
+
+  return <CarouselContainer options={settings}>{children}</CarouselContainer>;
+}

--- a/src/components/carousel/MyCarousel.tsx
+++ b/src/components/carousel/MyCarousel.tsx
@@ -1,6 +1,5 @@
-import CarouselContainer, {
-  type CarouselOptions,
-} from '@/components/carousel/custom-carousel/CarouselContainer';
+import CarouselContainer from '@/components/carousel/custom-carousel/CarouselContainer';
+import type { CarouselOptions } from '@/components/carousel/custom-carousel/types';
 
 type MyCarouselProps = {
   children: React.ReactNode;
@@ -11,7 +10,9 @@ export default function MyCarousel({ children }: MyCarouselProps) {
     slidesToShow: 6,
     slidesToScroll: 5,
     draggable: true,
-    infinite: false,
+    swipeable: true,
+    infinite: true,
+    autoPlay: false,
     prevArrow: (
       <div className="flex justify-center items-center bg-gray-400 px-2 py-4 rounded-md" />
     ),

--- a/src/components/carousel/custom-carousel/CarouselContainer.tsx
+++ b/src/components/carousel/custom-carousel/CarouselContainer.tsx
@@ -20,6 +20,7 @@ export default function CarouselContainer({ children, options }: CarouselContain
       visibleCount: showSlidesCnt || 1,
       scrollCount,
       infinite: isInfinite,
+      autoPlay: true,
     });
 
   // const scrollSlidesCnt = options?.slidesToScroll || 1;

--- a/src/components/carousel/custom-carousel/CarouselContainer.tsx
+++ b/src/components/carousel/custom-carousel/CarouselContainer.tsx
@@ -20,7 +20,10 @@ export default function CarouselContainer({ children, options }: CarouselContain
       visibleCount: showSlidesCnt || 1,
       scrollCount,
       infinite: isInfinite,
-      autoPlay: true,
+      autoPlay: options?.autoPlay,
+      autoPlaySpeed: options?.autoPlaySpeed,
+      draggable: options?.draggable,
+      swipeable: options?.swipeable,
     });
 
   const getArrowButton = (direction: Direction) => {

--- a/src/components/carousel/custom-carousel/CarouselContainer.tsx
+++ b/src/components/carousel/custom-carousel/CarouselContainer.tsx
@@ -1,0 +1,107 @@
+import ArrowButton from '@/components/button/ArrowButton';
+import React, { cloneElement, isValidElement, useRef, useState, type ReactElement } from 'react';
+
+export type CarouselOptions = {
+  draggable?: boolean;
+  slidesToShow?: number;
+  slidesToScroll?: number;
+  infinite?: boolean;
+  prevArrow?: React.JSX.Element;
+  nextArrow?: React.JSX.Element;
+};
+
+type CarouselContainerProps = {
+  children: React.ReactNode;
+  options?: CarouselOptions;
+};
+
+type ChildElementProps = {
+  className?: string;
+  style?: object;
+  onClick?: () => void;
+  'data-index'?: number;
+};
+type ChildProps = ReactElement<ChildElementProps>;
+type Direction = 'prev' | 'next';
+
+export default function CarouselContainer({ children, options }: CarouselContainerProps) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const wrapperRef = useRef<HTMLUListElement>(null);
+
+  const scrollSlidesCnt = options?.slidesToScroll || 1;
+  const showSlidesCnt = options?.slidesToShow || 1;
+  const childrenLength = React.Children.count(children);
+
+  const handleClickArrow = (direction: Direction) => {
+    if (direction === 'next') {
+      if (currentIndex + showSlidesCnt < childrenLength) {
+        const _newCurrentIndex = Math.min(
+          currentIndex + scrollSlidesCnt,
+          childrenLength - showSlidesCnt
+        );
+
+        setCurrentIndex(_newCurrentIndex);
+      }
+    } else {
+      if (currentIndex - showSlidesCnt >= 0) {
+        setCurrentIndex((prev) => prev - scrollSlidesCnt);
+      } else {
+        setCurrentIndex(0);
+      }
+    }
+  };
+
+  const getArrowButton = (direction: Direction) => {
+    return (
+      <div
+        className={`arrow absolute top-1/2 -translatey-1/2 z-10 cursor-pointer ${
+          direction === 'prev' ? '-left-12' : '-right-12'
+        }`}
+      >
+        {React.cloneElement(
+          options!.prevArrow as ChildProps,
+          {
+            className: `${
+              (options!.prevArrow!.props as ChildElementProps).className ?? ''
+            } custom-button`,
+            onClick: () => handleClickArrow(direction === 'prev' ? 'prev' : 'next'),
+          },
+          <div
+            className={`rounded-full p-3 before:relative bg-white ${
+              direction === 'next' ? 'rotate-y-180' : ''
+            }`}
+          >
+            <ArrowButton />
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  const getPosition = () => {
+    if (!wrapperRef.current) return;
+
+    const percentPerSlide = wrapperRef.current.offsetWidth / (options?.slidesToShow || 1);
+    return { transform: `translateX(-${currentIndex * percentPerSlide}px)` };
+  };
+
+  return (
+    <div className="container w-full relative">
+      {options?.prevArrow && isValidElement(options.prevArrow) && getArrowButton('prev')}
+      <div className="wrapper w-full h-fit overflow-hidden">
+        <ul className={`flex transition duration-500`} style={getPosition()} ref={wrapperRef}>
+          {React.Children.map(children, (child, idx) =>
+            isValidElement(child)
+              ? cloneElement(child as ChildProps, {
+                  className: `${(child.props as ChildElementProps).className ?? ''} shrink-0`,
+                  style: { width: `calc(100% / ${options?.slidesToShow || 1})` },
+                  'data-index': idx,
+                })
+              : child
+          )}
+        </ul>
+      </div>
+      {options?.nextArrow && isValidElement(options.nextArrow) && getArrowButton('next')}
+    </div>
+  );
+}

--- a/src/components/carousel/custom-carousel/CarouselContainer.tsx
+++ b/src/components/carousel/custom-carousel/CarouselContainer.tsx
@@ -12,11 +12,13 @@ import React, { isValidElement } from 'react';
 export default function CarouselContainer({ children, options }: CarouselContainerProps) {
   const isInfinite = options?.infinite;
   const showSlidesCnt = options?.slidesToShow || 1;
+  const scrollCount = options?.slidesToScroll || 1;
 
   const { items, wrapperRef, trackRef, handleNext, handlePrev, bind, itemStyle, trackStyle } =
     useCarousel({
       items: getValidItems({ children, visibleCount: showSlidesCnt || 1 }),
       visibleCount: showSlidesCnt || 1,
+      scrollCount,
       infinite: isInfinite,
     });
 

--- a/src/components/carousel/custom-carousel/CarouselContainer.tsx
+++ b/src/components/carousel/custom-carousel/CarouselContainer.tsx
@@ -23,38 +23,6 @@ export default function CarouselContainer({ children, options }: CarouselContain
       autoPlay: true,
     });
 
-  // const scrollSlidesCnt = options?.slidesToScroll || 1;
-  // const childrenLength = React.Children.count(children);
-
-  // const [currentIndex, setCurrentIndex] = useState(isInfinite ? showSlidesCnt + 1 : 0);
-
-  // const _items = getValidItems({ children, visibleCount: options?.slidesToShow || 1 });
-  // const [items, setItems] = useState<React.ReactNode>([]);
-  // const [transition, setTransition] = useState(true);
-
-  // const handleClickArrow = (direction: Direction) => {
-  //   if (direction === 'next') {
-  //     if (currentIndex + showSlidesCnt < childrenLength) {
-  //       const _newCurrentIndex = Math.min(
-  //         currentIndex + scrollSlidesCnt,
-  //         childrenLength - showSlidesCnt
-  //       );
-
-  //       console.log('dd: ', currentIndex, ', slidesCnt: ', scrollSlidesCnt);
-
-  //       setCurrentIndex(_newCurrentIndex);
-  //     } else if (isInfinite) {
-  //       setCurrentIndex(10);
-  //     }
-  //   } else {
-  //     if (currentIndex - showSlidesCnt >= 0) {
-  //       setCurrentIndex((prev) => prev - scrollSlidesCnt);
-  //     } else {
-  //       setCurrentIndex(0);
-  //     }
-  //   }
-  // };
-
   const getArrowButton = (direction: Direction) => {
     return (
       <div
@@ -68,7 +36,6 @@ export default function CarouselContainer({ children, options }: CarouselContain
             className: `${
               (options!.prevArrow!.props as ChildElementProps).className ?? ''
             } custom-button`,
-            // onClick: () => handleClickArrow(direction === 'prev' ? 'prev' : 'next'),
             onClick: direction === 'prev' ? handlePrev : handleNext,
           },
           <div
@@ -82,24 +49,6 @@ export default function CarouselContainer({ children, options }: CarouselContain
       </div>
     );
   };
-
-  // const getPosition = (needsTransition: boolean = true) => {
-  //   if (!trackRef.current) return;
-
-  //   const percentPerSlide = trackRef.current.offsetWidth / (options?.slidesToShow || 1);
-  //   return {
-  //     transform: `translateX(-${currentIndex * percentPerSlide}px)`,
-  //     transition: needsTransition ? '' : 'none',
-  //   };
-  // };
-
-  // useLayoutEffect(() => {
-  //   if (trackRef.current) {
-  //     const data = isInfinite
-  //       ? [..._items.slice(-showSlidesCnt), ..._items, ..._items.slice(0, showSlidesCnt)]
-  //       : [..._items];
-  //   }
-  // }, []);
 
   return (
     <div className="container flex items-center w-full relative">

--- a/src/components/carousel/custom-carousel/hooks/useCarousel.ts
+++ b/src/components/carousel/custom-carousel/hooks/useCarousel.ts
@@ -1,0 +1,111 @@
+import { useRef, useState, useEffect, useCallback } from 'react';
+
+interface UseCarouselProps<T> {
+  items: T[];
+  visibleCount: number;
+  infinite?: boolean;
+  delay?: number; // 디바운싱 딜레이 (ms)
+}
+
+export function useCarousel<T>({
+  items,
+  visibleCount,
+  infinite = false,
+  delay = 400,
+}: UseCarouselProps<T>) {
+  const total = items.length;
+  const extended = infinite
+    ? [...items.slice(-visibleCount), ...items, ...items.slice(0, visibleCount)]
+    : [...items];
+
+  const [index, setIndex] = useState(infinite ? visibleCount : 0);
+  const [isTransitioning, setIsTransitioning] = useState(false);
+  const [isResetting, setIsResetting] = useState(false);
+
+  const trackRef = useRef<HTMLUListElement>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const moveTo = useCallback(
+    (i: number, withTransition = true) => {
+      if (!trackRef.current || !wrapperRef.current) return;
+
+      const itemWidth = wrapperRef.current.offsetWidth / visibleCount;
+      trackRef.current.style.transition = withTransition ? 'transform 0.5s ease' : 'none';
+      trackRef.current.style.transform = `translateX(-${itemWidth * i}px)`;
+    },
+    [visibleCount]
+  );
+
+  useEffect(() => {
+    moveTo(index);
+    setIsTransitioning(true);
+  }, [index, moveTo]);
+
+  const handleTransitionEnd = () => {
+    setIsTransitioning(false);
+
+    if (!infinite) return;
+
+    // 무한 캐러셀 인덱스 보정
+    if (index === 0) {
+      const resetIndex = total;
+      setIsResetting(true);
+      setIndex(resetIndex);
+      requestAnimationFrame(() => {
+        moveTo(resetIndex, false);
+        setIsResetting(false);
+      });
+    } else if (index === total + visibleCount) {
+      const resetIndex = visibleCount;
+      setIsResetting(true);
+      setIndex(resetIndex);
+      requestAnimationFrame(() => {
+        moveTo(resetIndex, false);
+        setIsResetting(false);
+      });
+    }
+  };
+
+  const debouncedAction = (action: () => void) => {
+    if (isTransitioning || isResetting) return;
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(action, delay);
+  };
+
+  const handleNext = () => {
+    debouncedAction(() => setIndex((prev) => prev + 1));
+  };
+
+  const handlePrev = () => {
+    debouncedAction(() => setIndex((prev) => prev - 1));
+  };
+
+  const getItemStyle = () => {
+    if (!wrapperRef.current) return {};
+    const width = wrapperRef.current.offsetWidth / visibleCount;
+    return { width: `${width}px` };
+  };
+
+  const getTrackStyle = () => {
+    return {
+      transform: `rotateX(0)`,
+      width: `${(extended.length / visibleCount) * 100}%`,
+      display: 'flex',
+    };
+  };
+
+  return {
+    items: extended,
+    index,
+    wrapperRef,
+    trackRef,
+    handleNext,
+    handlePrev,
+    bind: {
+      onTransitionEnd: handleTransitionEnd,
+    },
+    itemStyle: getItemStyle(),
+    trackStyle: getTrackStyle(),
+  };
+}

--- a/src/components/carousel/custom-carousel/hooks/useCarousel.ts
+++ b/src/components/carousel/custom-carousel/hooks/useCarousel.ts
@@ -6,6 +6,8 @@ interface UseCarouselProps<T> {
   scrollCount?: number;
   infinite?: boolean;
   delay?: number;
+  autoPlay?: boolean;
+  autoPlaySpeed?: number;
 }
 
 export function useCarousel<T>({
@@ -14,6 +16,8 @@ export function useCarousel<T>({
   scrollCount = 1,
   infinite = false,
   delay = 250,
+  autoPlay,
+  autoPlaySpeed = 3000,
 }: UseCarouselProps<T>) {
   const total = items.length;
   const extended = infinite
@@ -44,6 +48,10 @@ export function useCarousel<T>({
     },
     [visibleCount]
   );
+
+  useEffect(() => {
+    if (autoPlay) setInterval(handleNext, autoPlaySpeed);
+  }, [autoPlay]);
 
   useEffect(() => {
     moveTo(index);

--- a/src/components/carousel/custom-carousel/hooks/useCarousel.ts
+++ b/src/components/carousel/custom-carousel/hooks/useCarousel.ts
@@ -4,14 +4,14 @@ interface UseCarouselProps<T> {
   items: T[];
   visibleCount: number;
   infinite?: boolean;
-  delay?: number; // 디바운싱 딜레이 (ms)
+  delay?: number;
 }
 
 export function useCarousel<T>({
   items,
   visibleCount,
   infinite = false,
-  delay = 400,
+  delay = 250,
 }: UseCarouselProps<T>) {
   const total = items.length;
   const extended = infinite
@@ -28,18 +28,23 @@ export function useCarousel<T>({
 
   const moveTo = useCallback(
     (i: number, withTransition = true) => {
+      setIsTransitioning(true);
+
       if (!trackRef.current || !wrapperRef.current) return;
 
       const itemWidth = wrapperRef.current.offsetWidth / visibleCount;
       trackRef.current.style.transition = withTransition ? 'transform 0.5s ease' : 'none';
       trackRef.current.style.transform = `translateX(-${itemWidth * i}px)`;
+
+      if (withTransition) {
+        setTimeout(() => setIsTransitioning(false), 600);
+      }
     },
     [visibleCount]
   );
 
   useEffect(() => {
     moveTo(index);
-    setIsTransitioning(true);
   }, [index, moveTo]);
 
   const handleTransitionEnd = () => {

--- a/src/components/carousel/custom-carousel/hooks/useCarousel.ts
+++ b/src/components/carousel/custom-carousel/hooks/useCarousel.ts
@@ -3,6 +3,7 @@ import { useRef, useState, useEffect, useCallback } from 'react';
 interface UseCarouselProps<T> {
   items: T[];
   visibleCount: number;
+  scrollCount?: number;
   infinite?: boolean;
   delay?: number;
 }
@@ -10,6 +11,7 @@ interface UseCarouselProps<T> {
 export function useCarousel<T>({
   items,
   visibleCount,
+  scrollCount = 1,
   infinite = false,
   delay = 250,
 }: UseCarouselProps<T>) {
@@ -79,11 +81,11 @@ export function useCarousel<T>({
   };
 
   const handleNext = () => {
-    debouncedAction(() => setIndex((prev) => prev + 1));
+    debouncedAction(() => setIndex((prev) => prev + scrollCount));
   };
 
   const handlePrev = () => {
-    debouncedAction(() => setIndex((prev) => prev - 1));
+    debouncedAction(() => setIndex((prev) => prev - scrollCount));
   };
 
   const getItemStyle = () => {

--- a/src/components/carousel/custom-carousel/types/index.ts
+++ b/src/components/carousel/custom-carousel/types/index.ts
@@ -7,6 +7,8 @@ export type CarouselOptions = {
   infinite?: boolean;
   prevArrow?: React.JSX.Element;
   nextArrow?: React.JSX.Element;
+  autoPlay?: boolean;
+  autoPlaySpeed?: number;
 };
 
 export type CarouselContainerProps = {

--- a/src/components/carousel/custom-carousel/types/index.ts
+++ b/src/components/carousel/custom-carousel/types/index.ts
@@ -9,6 +9,8 @@ export type CarouselOptions = {
   nextArrow?: React.JSX.Element;
   autoPlay?: boolean;
   autoPlaySpeed?: number;
+  draggble?: boolean;
+  swipeable?: boolean;
 };
 
 export type CarouselContainerProps = {

--- a/src/components/carousel/custom-carousel/types/index.ts
+++ b/src/components/carousel/custom-carousel/types/index.ts
@@ -1,0 +1,24 @@
+import type { ReactElement } from 'react';
+
+export type CarouselOptions = {
+  draggable?: boolean;
+  slidesToShow?: number;
+  slidesToScroll?: number;
+  infinite?: boolean;
+  prevArrow?: React.JSX.Element;
+  nextArrow?: React.JSX.Element;
+};
+
+export type CarouselContainerProps = {
+  children: React.ReactNode;
+  options?: CarouselOptions;
+};
+
+export type ChildElementProps = {
+  className?: string;
+  style?: object;
+  onClick?: () => void;
+  'data-index'?: number;
+};
+export type ChildProps = ReactElement<ChildElementProps>;
+export type Direction = 'prev' | 'next';

--- a/src/components/carousel/custom-carousel/utils/utils.ts
+++ b/src/components/carousel/custom-carousel/utils/utils.ts
@@ -1,0 +1,21 @@
+import type { ChildElementProps, ChildProps } from '@/components/carousel/custom-carousel/types';
+import React, { cloneElement, isValidElement } from 'react';
+
+type GetValidItemsProps = {
+  children: React.ReactNode;
+  visibleCount?: number;
+};
+
+export const getValidItems = ({ children, visibleCount }: GetValidItemsProps) => {
+  return (
+    React.Children.map(children, (child, idx) =>
+      isValidElement(child)
+        ? cloneElement(child as ChildProps, {
+            className: `${(child.props as ChildElementProps).className ?? ''} shrink-0`,
+            style: { width: `calc(100% / ${visibleCount || 1})` },
+            'data-index': idx,
+          })
+        : child
+    ) || []
+  );
+};


### PR DESCRIPTION
## 연관된 이슈

> #8 

## 작업 내용

- carousel 직접 구현: slidesToShow, slidesToScroll 기능, 좌우 슬라이드 버튼, infinite scroll, auto play(& speed), draggable, 터치 패드 스와이프 기능

## 스크린샷
